### PR TITLE
Implemented TestKnnGraph unit tests

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/KnnGraphFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/KnnGraphFormat.java
@@ -45,7 +45,7 @@ public abstract class KnnGraphFormat {
   public static KnnGraphFormat EMPTY = new KnnGraphFormat() {
     @Override
     public KnnGraphWriter fieldsWriter(SegmentWriteState state) throws IOException {
-      throw new UnsupportedOperationException();
+      throw new UnsupportedOperationException("Attempt to write EMPTY KnnGraphValues: maybe you forgot to use codec=Lucene90");
     }
 
     @Override

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90FieldInfosFormat.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90FieldInfosFormat.java
@@ -240,8 +240,9 @@ public final class Lucene90FieldInfosFormat extends FieldInfosFormat {
     switch (distFunc) {
       case NONE:
       case MANHATTAN:
-      case COSINE:
+      case EUCLIDEAN:
         return (byte)distFunc.getId();
+      case COSINE:
       default:
         // BUG
         throw new AssertionError("unhandled DistanceFunction: " + distFunc);

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90KnnGraphWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene90/Lucene90KnnGraphWriter.java
@@ -18,22 +18,30 @@
 package org.apache.lucene.codecs.lucene90;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.KnnGraphReader;
 import org.apache.lucene.codecs.KnnGraphWriter;
+import org.apache.lucene.index.DocIDMerger;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.index.KnnGraphValues;
+import org.apache.lucene.index.KnnGraphValuesWriter;
+import org.apache.lucene.index.MergeState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.VectorValues;
-import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Counter;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.IntsRef;
+
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
 /**
  * Writes vector values and knn graphs to index segments.
@@ -44,7 +52,7 @@ public final class Lucene90KnnGraphWriter extends KnnGraphWriter {
 
   private boolean finished;
 
-  public Lucene90KnnGraphWriter(SegmentWriteState state) throws IOException {
+  Lucene90KnnGraphWriter(SegmentWriteState state) throws IOException {
     assert state.fieldInfos.hasVectorValues();
 
     String metaFileName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, Lucene90KnnGraphFormat.META_EXTENSION);
@@ -76,7 +84,10 @@ public final class Lucene90KnnGraphWriter extends KnnGraphWriter {
 
   @Override
   public void writeField(FieldInfo fieldInfo, KnnGraphReader values) throws IOException {
-    Map<Integer, Long> docToOffset = new HashMap<>();
+    // we require a TreeMap so that we can iterate over docid keys in order. Instead we should move
+    // to the IndexedDISI encoding used by BinaryDocValues
+    Map<Integer, Long> docToOffset = new TreeMap<>();
+    List<Integer> enterPoints = new ArrayList<>();
     long vectorDataOffset = vectorData.getFilePointer();
     long graphDataOffset = graphData.getFilePointer();
 
@@ -85,15 +96,13 @@ public final class Lucene90KnnGraphWriter extends KnnGraphWriter {
     VectorValues vectors = values.getVectorValues(fieldInfo.name);
     KnnGraphValues graph = values.getGraphValues(fieldInfo.name);
 
-    for (int docV = vectors.nextDoc(), docG = graph.nextDoc();
-         docV != DocIdSetIterator.NO_MORE_DOCS && docG != DocIdSetIterator.NO_MORE_DOCS;
+    int docV, docG;
+    for (docV = vectors.nextDoc(), docG = graph.nextDoc();
+         docV != NO_MORE_DOCS && docG != NO_MORE_DOCS;
          docV = vectors.nextDoc(), docG = graph.nextDoc()) {
       assert docV == docG;  // must be same
 
-      // write vector value
-      byte[] binaryValue = vectors.binaryValue();
-      VectorValues.verifyNumDimensions(binaryValue, numDims);
-      vectorData.writeBytes(binaryValue, binaryValue.length);
+      writeVectorValue(numDims, vectors);
 
       // write knn graph value
       docToOffset.put(docG, graphData.getFilePointer() - graphDataOffset);
@@ -103,26 +112,37 @@ public final class Lucene90KnnGraphWriter extends KnnGraphWriter {
       graphData.writeInt(maxLevel);
       for (int l = graph.getMaxLevel(); l >= 0; l--) {
         IntsRef friends = graph.getFriends(l);
-        assert friends.length > 0 : "doc " + docG + " has empty friends list at level=" + l;
+        // assert friends.length > 0 : "doc " + docG + " has empty friends list at level=" + l;
         graphData.writeInt(friends.length);
-        int stop = friends.offset + friends.length;
-        // sort friend ids
-        Arrays.sort(friends.ints, friends.offset, stop);
-        // write the smallest friend id
-        graphData.writeVInt(friends.ints[friends.offset]);
-        for (int i = friends.offset + 1; i < stop; i++) {
-          // write delta
-          int delta = friends.ints[i] - friends.ints[i - 1];
-          assert delta > 0;
-          graphData.writeVInt(delta);
+        if (friends.length > 0) {
+          int stop = friends.offset + friends.length;
+          // sort friend ids
+          Arrays.sort(friends.ints, friends.offset, stop);
+          // write the smallest friend id
+          graphData.writeVInt(friends.ints[friends.offset]);
+          for (int i = friends.offset + 1; i < stop; i++) {
+            // write delta
+            int delta = friends.ints[i] - friends.ints[i - 1];
+            assert delta > 0;
+            graphData.writeVInt(delta);
+          }
         }
       }
     }
+    assert docV == NO_MORE_DOCS;  // must be exhausted
+    assert docG == NO_MORE_DOCS;    // must be exhausted
 
     long vectorDataLength = vectorData.getFilePointer() - vectorDataOffset;
     long graphDataLength = graphData.getFilePointer() - graphDataOffset;
 
     writeMeta(fieldInfo, vectorDataOffset, vectorDataLength, graphDataOffset, graphDataLength, graph.getTopLevel(), graph.getEnterPoints(), docToOffset);
+  }
+
+  private void writeVectorValue(int numDims, VectorValues vectors) throws IOException {
+    // write vector value
+    BytesRef binaryValue = vectors.binaryValue();
+    VectorValues.verifyNumDimensions(binaryValue.length, numDims);
+    vectorData.writeBytes(binaryValue.bytes, binaryValue.offset, binaryValue.length);
   }
 
   private void writeMeta(FieldInfo field, long vectorDataOffset, long vectorDataLength, long graphDataOffset, long graphDataLength,
@@ -139,8 +159,194 @@ public final class Lucene90KnnGraphWriter extends KnnGraphWriter {
     }
     meta.writeInt(docToOffset.size());
     for (Map.Entry<Integer, Long> entry : docToOffset.entrySet()) {
+      // these are not in sorted order, yet we write the vectors in order by docid
       meta.writeVInt(entry.getKey());
       meta.writeVLong(entry.getValue());
+    }
+  }
+
+  /*
+  @Override
+  public void merge(MergeState mergeState) throws IOException {
+    for (KnnGraphReader reader : mergeState.knnGraphReaders) {
+      if (reader != null) {
+        reader.checkIntegrity();
+      }
+    }
+    for (FieldInfo fieldInfo : mergeState.mergeFieldInfos) {
+      if (fieldInfo.hasVectorValues()) {
+        mergeKnnGraph(fieldInfo, mergeState);
+      }
+    }
+    finish();
+  }
+  */
+
+  /**
+   * Merges the segment HNSW graphs by constructing a new merged graph using HNSWGraph
+   */
+  private void mergeKnnGraph(FieldInfo mergeFieldInfo, final MergeState mergeState) throws IOException {
+    // We must compute the entire merged field in memory since each document's values depend on its neighbors
+    //mergeState.infoStream.message("ReferenceDocValues", "merging " + mergeState.segmentInfo);
+    List<VectorValuesSub> subs = new ArrayList<>();
+    int dimension = -1;
+    for (int i = 0 ; i < mergeState.knnGraphReaders.length; i++) {
+      KnnGraphReader graphReader = mergeState.knnGraphReaders[i];
+      if (graphReader != null) {
+        if (mergeFieldInfo != null && mergeFieldInfo.hasVectorValues()) {
+          int segmentDimension = mergeFieldInfo.getVectorNumDimensions();
+          if (dimension == -1) {
+            dimension = segmentDimension;
+          } else if (dimension != segmentDimension) {
+            throw new IllegalStateException("Varying dimensions for vector-valued field " + mergeFieldInfo.name
+                + ": " + dimension + "!=" + segmentDimension);
+          }
+          VectorValues values = graphReader.getVectorValues(mergeFieldInfo.name);
+          subs.add(new VectorValuesSub(i, mergeState.docMaps[i], values));
+        }
+      }
+    }
+    // Create a new KnnGraphValues by iterating over the vectors, searching for
+    // its nearest neighbor vectors in the newly merged segments' vectors, mapping the resulting
+    // docids using docMaps in the mergeState.
+    MultiVectorValues multiVectors = new MultiVectorValues(subs, mergeState.maxDocs);
+    KnnGraphValuesWriter valuesWriter = new KnnGraphValuesWriter(mergeFieldInfo, Counter.newCounter());
+    for (int i = 0; i < subs.size(); i++) {
+      VectorValuesSub sub = subs.get(i);
+      MergeState.DocMap docMap = mergeState.docMaps[sub.segmentIndex];
+      // nocommit: test sorted index and test index with deletions
+      int docid;
+      while ((docid = sub.nextDoc()) != NO_MORE_DOCS) {
+        int mappedDocId = docMap.get(docid);
+        assert sub.values.docID() == docid;
+        assert docid == multiVectors.unmap(mappedDocId) : "unmap mismatch " + docid + " != " + multiVectors.unmap(mappedDocId);
+        valuesWriter.addValue(mappedDocId, sub.values.binaryValue());
+      }
+    }
+    valuesWriter.flush(null, this);
+    //writeField(mergeFieldInfo, valuesWriter.getGraphValues(), valuesWriter.getVectorValues());
+    //mergeState.infoStream.message("ReferenceDocValues", " mergeReferenceField done: " + mergeState.segmentInfo);
+  }
+
+  /** Tracks state of one binary sub-reader that we are merging */
+  private static class VectorValuesSub extends DocIDMerger.Sub {
+
+    final VectorValues values;
+    final int segmentIndex;
+
+    VectorValuesSub(int segmentIndex, MergeState.DocMap docMap, VectorValues values) {
+      super(docMap);
+      this.values = values;
+      this.segmentIndex = segmentIndex;
+      assert values.docID() == -1;
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      return values.nextDoc();
+    }
+  }
+
+  // provides a view over multiple VectorValues by concatenating their docid spaces
+  private static class MultiVectorValues extends VectorValues {
+    private final VectorValuesSub[] subValues;
+    private final int[] docBase;
+    private final int[] segmentMaxDocs;
+    private final int cost;
+
+    private int whichSub;
+
+    MultiVectorValues(List<VectorValuesSub> subs, int[] maxDocs) throws IOException {
+      this.subValues = new VectorValuesSub[subs.size()];
+      // TODO: this complicated logic needs its own test
+      // maxDocs actually says *how many* docs there are, not what the number of the max doc is
+      int maxDoc = -1;
+      int lastMaxDoc = -1;
+      segmentMaxDocs = new int[subs.size() - 1];
+      docBase = new int[subs.size()];
+      for (int i = 0, j = 0; j < subs.size(); i++) {
+        lastMaxDoc = maxDoc;
+        maxDoc += maxDocs[i];
+        if (i == subs.get(j).segmentIndex) {
+          // we may skip some segments if they have no docs with values for this field
+          if (j > 0) {
+            segmentMaxDocs[j - 1] = lastMaxDoc;
+          }
+          docBase[j] = lastMaxDoc + 1;
+          ++j;
+        }
+      }
+      int i = 0;
+      int totalCost = 0;
+      for (VectorValuesSub sub : subs) {
+        totalCost += sub.values.cost();
+        this.subValues[i++] = sub;
+      }
+      cost = totalCost;
+      whichSub = 0;
+    }
+
+    @Override
+    public long cost() {
+      return cost;
+    }
+
+    @Override
+    public int advance(int target) throws IOException {
+      int rebased = unmapSettingWhich(target);
+      if (rebased < 0) {
+        rebased = 0;
+      }
+      int segmentDocId = subValues[whichSub].values.advance(rebased);
+      if (segmentDocId == NO_MORE_DOCS) {
+        if (++whichSub < subValues.length) {
+          // Get the first document in the next segment; Note that all segments have values.
+          segmentDocId = subValues[whichSub].values.advance(0);
+        } else {
+          return NO_MORE_DOCS;
+        }
+      }
+      return docBase[whichSub] + segmentDocId;
+    }
+
+    @Override
+    public boolean seek(int target) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float[] vectorValue() throws IOException {
+      return subValues[whichSub].values.vectorValue();
+    }
+
+    int unmap(int docid) {
+      // map from global (merged) to segment-local (unmerged)
+      // like mapDocid but no side effect - used for assertion
+      return docid - docBase[findSegment(docid)];
+    }
+
+    private int unmapSettingWhich(int target) {
+      whichSub = findSegment(target);
+      return target - docBase[whichSub];
+    }
+
+    private int findSegment(int docid) {
+      int segment = Arrays.binarySearch(segmentMaxDocs, docid);
+      if (segment < 0) {
+        return -1 - segment;
+      } else {
+        return segment;
+      }
+    }
+
+    @Override
+    public int docID() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int nextDoc() throws IOException {
+      throw new UnsupportedOperationException();
     }
   }
 

--- a/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
+++ b/lucene/core/src/java/org/apache/lucene/index/CodecReader.java
@@ -222,7 +222,7 @@ public abstract class CodecReader extends LeafReader implements Accountable {
   }
 
   @Override
-  public KnnGraphValues getKnnGraphValues(String field) throws IOException {
+  public final KnnGraphValues getKnnGraphValues(String field) throws IOException {
     ensureOpen();
     FieldInfo fi = getFieldInfos().fieldInfo(field);
     if (fi == null || fi.getVectorNumDimensions() == 0) {

--- a/lucene/core/src/java/org/apache/lucene/index/DefaultIndexingChain.java
+++ b/lucene/core/src/java/org/apache/lucene/index/DefaultIndexingChain.java
@@ -308,7 +308,7 @@ final class DefaultIndexingChain extends DocConsumer {
     KnnGraphWriter knnGraphWriter = null;
     boolean success = false;
     try {
-      for (int i=0;i<fieldHash.length;i++) {
+      for (int i = 0; i<fieldHash.length; i++) {
         PerField perField = fieldHash[i];
         while (perField != null) {
           if (perField.knnGraphValuesWriter != null) {
@@ -325,7 +325,7 @@ final class DefaultIndexingChain extends DocConsumer {
               knnGraphWriter = fmt.fieldsWriter(state);
             }
 
-            perField.knnGraphValuesWriter.flush(state, sortMap, knnGraphWriter);
+            perField.knnGraphValuesWriter.flush(sortMap, knnGraphWriter);
             perField.knnGraphValuesWriter = null;
           } else if (perField.fieldInfo.getVectorNumDimensions() != 0) {
             // BUG

--- a/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
+++ b/lucene/core/src/java/org/apache/lucene/index/FieldInfo.java
@@ -382,6 +382,13 @@ public final class FieldInfo {
   public boolean hasVectors() {
     return storeTermVector;
   }
+
+  /**
+   * @return true if any (numeric) vector values exist for this field
+   */
+  public boolean hasVectorValues() {
+    return vectorNumDimensions > 0;
+  }
   
   /**
    * Get a codec attribute value, or null if it does not exist

--- a/lucene/core/src/java/org/apache/lucene/index/MergeState.java
+++ b/lucene/core/src/java/org/apache/lucene/index/MergeState.java
@@ -78,7 +78,7 @@ public class MergeState {
   /** Point readers to merge */
   public final PointsReader[] pointsReaders;
 
-  /** Knn graph readers to merge */
+  /** KNN Graph readers to merge */
   public final KnnGraphReader[] knnGraphReaders;
 
   /** Max docs per reader */

--- a/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java
+++ b/lucene/core/src/java/org/apache/lucene/index/SegmentCoreReaders.java
@@ -178,7 +178,7 @@ final class SegmentCoreReaders {
       Throwable th = null;
       try (Closeable finalizer = this::notifyCoreClosedListeners){
         IOUtils.close(termVectorsLocal, fieldsReaderLocal, fields, termVectorsReaderOrig, fieldsReaderOrig,
-                      cfsReader, normsProducer, pointsReader);
+                      cfsReader, normsProducer, pointsReader, knnGraphReader);
       }
     }
   }

--- a/lucene/core/src/java/org/apache/lucene/search/KnnGraphQuery.java
+++ b/lucene/core/src/java/org/apache/lucene/search/KnnGraphQuery.java
@@ -71,7 +71,6 @@ public class KnnGraphQuery extends Query implements Accountable {
    * @param ef number of per-segment candidates to be scored/collected. the collector does not return results exceeding {@code ef}.
    *           increasing this value leads higher recall at the expense of the search speed.
    * @param reader index reader
-   * @throws IOException
    */
   public KnnGraphQuery(String field, float[] queryVector, int ef, IndexReader reader) throws IOException {
     this.field = field;

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraphWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/HNSWGraphWriter.java
@@ -34,6 +34,8 @@ public final class HNSWGraphWriter implements Accountable {
   private static final int MAX_LEVEL_LIMIT = 5;
   // default random seed for level generation
   private static final long DEFAULT_RAND_SEED = System.currentTimeMillis();
+  // expose for testing. TODO: make a better way to initialize this
+  public static long RAND_SEED = DEFAULT_RAND_SEED;
   // default max connections per node
   public static final int DEFAULT_MAX_CONNECTIONS = 6;
   // default max connections per node at layer zero
@@ -56,7 +58,7 @@ public final class HNSWGraphWriter implements Accountable {
 
   /** Construct the builder with default configurations */
   public HNSWGraphWriter(int numDimensions, VectorValues.DistanceFunction distFunc) {
-    this(DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_CONNECTIONS_L0, DEFAULT_EF_CONST, DEFAULT_RAND_SEED, numDimensions, distFunc);
+    this(DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_CONNECTIONS_L0, DEFAULT_EF_CONST, RAND_SEED, numDimensions, distFunc);
   }
 
   /** Full constructor */
@@ -76,7 +78,7 @@ public final class HNSWGraphWriter implements Accountable {
   /** Inserts a doc with vector value to the graph */
   public void insert(int docId, BytesRef binaryValue) throws IOException {
     // add the vector value
-    float[] value = VectorValues.decode(binaryValue.bytes, numDimensions);
+    float[] value = VectorValues.decode(binaryValue, numDimensions);
     rawVectors.add(value);
     docsRef.grow(docId + 1);
     docsRef.setIntAt(docId, addedDocs++);

--- a/lucene/core/src/java/org/apache/lucene/util/hnsw/Layer.java
+++ b/lucene/core/src/java/org/apache/lucene/util/hnsw/Layer.java
@@ -17,9 +17,10 @@
 
 package org.apache.lucene.util.hnsw;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,10 @@ import org.apache.lucene.util.RamUsageEstimator;
 
 /** A knn graph that consists of connected friends (i.e. neighbors) lists. */
 final class Layer implements Accountable {
+
+  // Sentinel that indicates a document has no friends *ie does not participate in the graph*
+  // This is distinct from a document in a single-node graph, which has no friends *yet* (sad).
+  public static final Collection<Neighbor> NO_FRIENDS = Collections.unmodifiableSet(new HashSet<>());
 
   private final int level;
   private final Map<Integer, TreeSet<Neighbor>> friendsMap;
@@ -89,12 +94,13 @@ final class Layer implements Accountable {
     }
   }
 
-  List<Neighbor> getFriends(int node) {
-    TreeSet<Neighbor> friends = friendsMap.get(node);
-    if (friends == null) {
-      return Collections.emptyList();
+  Collection<Neighbor> getFriends(int node) {
+    Collection<Neighbor> friends = friendsMap.get(node);
+    if (friends != null) {
+      return friends;
+    } else {
+      return NO_FRIENDS;
     }
-    return List.copyOf(friends);
   }
 
   int size() {

--- a/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestKnnGraph.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.lucene.index;
+
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.VectorField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.search.KnnGraphQuery;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.IntsRef;
+import org.apache.lucene.util.LuceneTestCase;
+import org.junit.Before;
+
+import static org.apache.lucene.util.hnsw.HNSWGraphWriter.RAND_SEED;
+
+/** Tests indexing of a knn-graph */
+public class TestKnnGraph extends LuceneTestCase {
+
+  private static final String KNN_GRAPH_FIELD = "vector";
+
+  @Before
+  public void setup() {
+    RAND_SEED = random().nextLong();
+  }
+
+  /**
+   * Basic test of creating documents in a graph
+   */
+  public void testBasic() throws Exception {
+    try (Directory dir = newDirectory();
+         IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
+      int numDoc = atLeast(10);
+      int dimension = atLeast(3);
+      float[][] values = new float[numDoc][];
+      for (int i = 0; i < numDoc; i++) {
+        if (random().nextBoolean()) {
+          values[i] = new float[dimension];
+          for (int j = 0; j < dimension; j++) {
+            values[i][j] = random().nextFloat();
+          }
+        }
+        add(iw, i, values[i]);
+      }
+      assertConsistentGraph(iw, values);
+    }
+  }
+
+  public void testSingleDocument() throws Exception {
+    try (Directory dir = newDirectory();
+         IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
+      float[][] values = new float[][]{new float[]{0, 1, 2}};
+      add(iw, 0, values[0]);
+      assertConsistentGraph(iw, values);
+      iw.commit();
+      assertConsistentGraph(iw, values);
+    }
+  }
+
+  /**
+   * Verify that the graph properties are preserved when merging
+   */
+  public void testMerge() throws Exception {
+    try (Directory dir = newDirectory();
+         IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
+      int numDoc = atLeast(100);
+      int dimension = atLeast(10);
+      float[][] values = new float[numDoc][];
+      for (int i = 0; i < numDoc; i++) {
+        if (random().nextBoolean()) {
+          values[i] = new float[dimension];
+          for (int j = 0; j < dimension; j++) {
+            values[i][j] = random().nextFloat();
+          }
+        }
+        add(iw, i, values[i]);
+        if (random().nextInt(10) == 3) {
+          //System.out.println("commit @" + i);
+          iw.commit();
+        }
+      }
+      if (random().nextBoolean()) {
+        iw.forceMerge(1);
+      }
+      assertConsistentGraph(iw, values);
+    }
+  }
+
+  // TODO: testSorted
+  // TODO: testDeletions
+
+  /**
+   * Verify that searching does something reasonable
+   */
+  public void testSearch() throws Exception {
+    try (Directory dir = newDirectory();
+         IndexWriter iw = new IndexWriter(dir, newIndexWriterConfig(null))) {
+      // Add a document for every cartesian point  in an NxN square so we can
+      // easily know which are the nearest neighbors to every point. Insert by iterating
+      // using a prime number that is not a divisor of N*N so that we will hit each point once,
+      // and chosen so that points will be inserted in a deterministic
+      // but somewhat distributed pattern
+      int n = 5, stepSize = 17;
+      float[][] values = new float[n * n][];
+      int index = 0;
+      for (int i = 0; i < values.length; i++) {
+        // System.out.printf("%d: (%d, %d)\n", i, index % n, index / n);
+        values[i] = new float[]{index % n, index / n};
+        index = (index + stepSize) % (n * n);
+        add(iw, i, values[i]);
+        if (i == 13) {
+          // create 2 segments
+          iw.commit();
+        }
+      }
+      //System.out.println("");
+      if (random().nextBoolean()) {
+        iw.forceMerge(1);
+      }
+      assertConsistentGraph(iw, values);
+      try (DirectoryReader dr = DirectoryReader.open(iw)) {
+        IndexSearcher searcher = new IndexSearcher(dr);
+        // results are ordered by distance (descending) and docid (ascending);
+        // This is the docid ordering:
+        // column major, origin at upper left
+        //  0 15  5 20 10
+        //  3 18  8 23 13
+        //  6 21 11  1 16
+        //  9 24 14  4 19
+        // 12  2 17  7 22
+
+        // For this small graph it seems we can always get exact results with 2 probes
+        assertGraphSearch(new int[]{0, 15, 3, 18, 5}, new float[]{0f, 0.1f}, searcher);
+        assertGraphSearch(new int[]{11, 1, 8, 14, 21}, new float[]{2, 2}, searcher);
+        assertGraphSearch(new int[]{15, 18, 0, 3, 5},new float[]{0.3f, 0.8f}, searcher);
+      }
+    }
+  }
+
+  private void assertGraphSearch(int[] expected, float[] vector, IndexSearcher searcher) throws IOException {
+    TopDocs results = searcher.search(new KnnGraphQuery(KNN_GRAPH_FIELD, vector), 5);
+    assertResults(expected, results);
+  }
+
+  private void assertResults(int[] expected, TopDocs topDocs) {
+    String resultString = Arrays.asList(topDocs.scoreDocs).toString();
+    assertEquals(resultString, expected.length, topDocs.scoreDocs.length);
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(resultString, expected[i], topDocs.scoreDocs[i].doc);
+    }
+  }
+
+  private void assertConsistentGraph(IndexWriter iw, float[][] values) throws IOException {
+    int totalGraphDocs = 0;
+    try (DirectoryReader dr = DirectoryReader.open(iw)) {
+      for (LeafReaderContext ctx: dr.leaves()) {
+        LeafReader reader = ctx.reader();
+        VectorValues vectorValues = reader.getVectorValues(KNN_GRAPH_FIELD);
+        KnnGraphValues neighbors = reader.getKnnGraphValues(KNN_GRAPH_FIELD);
+        assertTrue((vectorValues == null) == (neighbors == null));
+        if (vectorValues == null) {
+          continue;
+        }
+        int[][] graph = new int[reader.maxDoc()][];
+        boolean singleNodeGraph = false;
+        int graphSize = 0;
+        for (int i = 0; i < reader.maxDoc(); i++) {
+          int id = Integer.parseInt(reader.document(i).get("id"));
+          if (values[id] == null) {
+            // documents without KnnGraphValues have no vectors or neighbors
+            assertNotEquals("document " + id + " was not expected to have values", i, vectorValues.advance(i));
+            assertNotEquals(i, neighbors.advance(i));
+          } else {
+            ++graphSize;
+            // documents with KnnGraphValues have the expected vectors
+            int doc = vectorValues.advance(i);
+            assertEquals("doc " + i + " with id=" + id + " has no vector value", i, doc);
+            float[] scratch = vectorValues.vectorValue();
+            assertArrayEquals("vector did not match for doc " + i + ", id=" + id + ": " + Arrays.toString(scratch),
+                values[id], scratch, 0f);
+            // We collect neighbors for analysis below
+            int nextWithNeighbors = neighbors.advance(i);
+            if (i == nextWithNeighbors) {
+              // FIXME: check every level, not only level 0
+              IntsRef friends = neighbors.getFriends(0);
+              if (friends.length == 0) {
+                //System.out.printf("knngraph @%d is singleton (advance returns %d)\n", i, nextWithNeighbors);
+                singleNodeGraph = true;
+              } else {
+                graph[i] = new int[friends.length];
+                System.arraycopy(friends.ints, friends.offset, graph[i], 0, friends.length);
+                //System.out.printf("knngraph @%d => %s\n", i, Arrays.toString(graph[i]));
+              }
+            } else {
+              // graph must have a single node
+              //System.out.printf("knngraph @%d is singleton (advance returns %d)\n", i, nextWithNeighbors);
+              singleNodeGraph = true;
+            }
+          }
+        }
+        if (singleNodeGraph) {
+          assertEquals("graph is not fully connected", 1, graphSize);
+        } else {
+          assertTrue("Graph has " + graphSize + " nodes, but one of them has no neighbors", graphSize > 1);
+        }
+        // assert that the graph in each leaf is connected and undirected (ie links are reciprocated)
+        assertReciprocal(graph);
+        assertConnected(graph);
+        totalGraphDocs += graphSize;
+      }
+    }
+    int expectedCount = 0;
+    for (float[] friends : values) {
+      if (friends != null) {
+        ++expectedCount;
+      }
+    }
+    assertEquals(expectedCount, totalGraphDocs);
+  }
+
+  private void assertReciprocal(int[][] graph) {
+    // The graph is undirected: if a -> b then b -> a.
+    for (int i = 0; i < graph.length; i++) {
+      if (graph[i] != null) {
+        for (int j = 0; j < graph[i].length; j++) {
+          int k = graph[i][j];
+          assertTrue("" + i + "->" + k + " is not reciprocated", Arrays.binarySearch(graph[k], i) >= 0);
+        }
+      }
+    }
+  }
+
+  private void assertConnected(int[][] graph) {
+    // every node in the graph is reachable from every other node
+    Set<Integer> visited = new HashSet<>();
+    List<Integer> queue = new LinkedList<>();
+    int count = 0;
+    for (int[] entry : graph) {
+      if (entry != null) {
+        if (queue.isEmpty()) {
+          queue.add(entry[0]); // start from any node
+          //System.out.println("start at " + entry[0]);
+        }
+        ++count;
+      }
+    }
+    while(queue.isEmpty() == false) {
+      int i = queue.remove(0);
+      assertNotNull("expected neighbors of " + i, graph[i]);
+      visited.add(i);
+      for (int j : graph[i]) {
+        if (visited.contains(j) == false) {
+          //System.out.println("  ... " + j);
+          queue.add(j);
+        }
+      }
+    }
+    // we visited each node exactly once
+    assertEquals("Attempted to walk entire graph but only visited " + visited.size(), count, visited.size());
+  }
+
+
+  private void add(IndexWriter iw, int id, float[] vector) throws IOException {
+    Document doc = new Document();
+    if (vector != null) {
+      doc.add(new VectorField(KNN_GRAPH_FIELD, vector, VectorValues.DistanceFunction.EUCLIDEAN));
+    }
+    doc.add(new StringField("id", Integer.toString(id), Field.Store.YES));
+    //System.out.println("add " + id + " " + Arrays.toString(vector));
+    iw.addDocument(doc);
+  }
+
+}


### PR DESCRIPTION
Hi @mocobeta this is a set of changes based on your branch. It mostly just adds a unit test and fixes some edge case bugs that came up when running that test. For example it now handles segments with 0 or 1 vector. I also included an alternative merge implementation as part of Lucene90KnnGraphWriter, but it is disabled. I had previously tested it and it works - I think we should start running some performance evaluations now! One concern I have is the number of Java Collections we use, and the copying we do, but let's not optimize until we have done some measurements.  I'll add some inline comments explaining the reasons for the changes